### PR TITLE
Support docker on windows hosts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
At the moment, when you try to run the docker file on windows, you quickly get into the problems of the command line saying `/bin/bash` is not a valid command.

This issue is caused that git for windows, by default, configures git to automatically change newlines to the Windows format on checkout, and this will in turn cause problems with docker, as that uses Linux internally, with its own format.

By forcing `*.sh` files to have the "Linux" line endings, this is no longer an issue.

Note that I needed to make some local files to the dockerfile to test it locally, because it was missing some dependencies.